### PR TITLE
Fix CLI steering command doc bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ enabling control and turning the steering right with 20% torque:
 rostopic pub /enable_disable roscco/EnableDisable -1 \
 '{header: {stamp: now}, enable_control: true}'
 
-rostopic pub /SteeringCommand roscco/SteeringCommand -1 \
+rostopic pub /steering_command roscco/SteeringCommand -1 \
 '{header: {stamp: now}, steering_torque: 0.2}'
 ```
 


### PR DESCRIPTION
Prior to this commit the documentation in this project's README.md had a typo in it's example for sending steering torque commands on the command line. This resulted in a failure to actuate steering with the example command using these docs as your guide. After this commit one reference to `SteeringCommand` has been revised to `steering_command`, the fix required for the command to succeed.