### PR TITLE
Niro apollo support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ target_link_libraries(
 
 endif()
 
-if(APOLLO AND KIA_SOUL_EV)
+if(APOLLO AND (KIA_SOUL_EV OR KIA_NIRO))
 
 find_package(catkin 
              REQUIRED COMPONENTS 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,6 @@ add_library(
 link_directories(
     /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/canbus/
     /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/control/
-    /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/localization/
     /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/common/proto
     /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/drivers/canbus/common/
     /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/drivers/canbus/proto/
@@ -217,13 +216,10 @@ target_link_libraries(
   ${PROJECT_NAME}_pid_control
   /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/canbus/proto/libcanbus_proto_lib.a
   /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/control/proto/libcontrol_proto_lib.a
-  /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/localization/proto/liblocalization_proto_lib.a
-  /apollo/bazel-apollo/bazel-out/local-dbg/bin/modules/localization/proto/libpose_proto_lib.a
   canbus_proto_lib
   protobuf
   canbus_lib
   control_lib
-  localization_lib
   canbus_common
   vehicle_signal_proto_lib
   pnc_point_proto_lib

--- a/example/roscco_apollo.cpp
+++ b/example/roscco_apollo.cpp
@@ -11,7 +11,6 @@ RosccoApollo::RosccoApollo()
     steering_sub = nh.subscribe( "/apollo/control", 1, &RosccoApollo::steeringCallback, this );  
     brake_sub = nh.subscribe( "/apollo/control", 1, &RosccoApollo::brakeCallback, this );
     throttle_sub = nh.subscribe( "/apollo/control", 1, &RosccoApollo::throttleCallback, this );
-    localization_sub = nh.subscribe( "/apollo/localization/pose", 1, &RosccoApollo::localizationCallback, this );
 
     can_frame_sub = nh.subscribe( "/can_frame", 1, &RosccoApollo::canFrameCallback, this );
 }
@@ -94,8 +93,7 @@ void RosccoApollo::canFrameCallback( const roscco::CanFrame& input )
         case KIA_SOUL_OBD_SPEED_CAN_ID:
         {
             #if defined( KIA_SOUL_EV )
-                speed_report = input.frame.data[3] 
-                                + input.frame.data[2] * 128;
+                speed_report = input.frame.data[3] + input.frame.data[2] * 128;
 
                 speed_report = speed_report * SPEED_RATIO;
 
@@ -123,13 +121,6 @@ void RosccoApollo::canFrameCallback( const roscco::CanFrame& input )
     output.set_speed_mps( speed_report );
 
     chassis_pub.publish( output );
-}
-
-
-void RosccoApollo::localizationCallback( const apollo::localization::LocalizationEstimate& input ) 
-{
-    std::cout << std::to_string( input.pose().position().x() ) << ", "
-              << std::to_string( input.pose().position().y() ) << "\n";
 }
 
 

--- a/example/roscco_apollo.cpp
+++ b/example/roscco_apollo.cpp
@@ -60,10 +60,6 @@ void RosccoApollo::canFrameCallback( const roscco::CanFrame& input )
                 throttle_report = input.frame.data[4];
             #elif defined( KIA_NIRO )
                 throttle_report = input.frame.data[7];
-
-                speed_report = input.frame.data[4];
-
-                speed_report = speed_report * SPEED_RATIO;
             #endif
 
             throttle_report = throttle_report * THROTTLE_RATIO;
@@ -95,18 +91,19 @@ void RosccoApollo::canFrameCallback( const roscco::CanFrame& input )
 
             break;
         }
-        case KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID:
+        case KIA_SOUL_OBD_SPEED_CAN_ID:
         {
             #if defined( KIA_SOUL_EV )
-                speed_report = input.frame.data[0] + input.frame.data[2]
-                                + input.frame.data[4] + input.frame.data[6];
-
-                speed_report += ( input.frame.data[1] + input.frame.data[3]
-                                + input.frame.data[5] + input.frame.data[7] ) * 256;
-
-                speed_report = speed_report / 4;
+                speed_report = input.frame.data[3] 
+                                + input.frame.data[2] * 128;
 
                 speed_report = speed_report * SPEED_RATIO;
+
+            #elif defined( KIA_NIRO )
+                speed_report = input.frame.data[0];
+
+                speed_report = speed_report * SPEED_RATIO;
+            
             #endif
 
             break;

--- a/example/roscco_apollo.cpp
+++ b/example/roscco_apollo.cpp
@@ -60,6 +60,10 @@ void RosccoApollo::canFrameCallback( const roscco::CanFrame& input )
                 throttle_report = input.frame.data[4];
             #elif defined( KIA_NIRO )
                 throttle_report = input.frame.data[7];
+
+                speed_report = input.frame.data[4];
+
+                speed_report = speed_report * SPEED_RATIO;
             #endif
 
             throttle_report = throttle_report * THROTTLE_RATIO;
@@ -93,15 +97,17 @@ void RosccoApollo::canFrameCallback( const roscco::CanFrame& input )
         }
         case KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID:
         {
-            speed_report = input.frame.data[0] + input.frame.data[2]
-                            + input.frame.data[4] + input.frame.data[6];
+            #if defined( KIA_SOUL_EV )
+                speed_report = input.frame.data[0] + input.frame.data[2]
+                                + input.frame.data[4] + input.frame.data[6];
 
                 speed_report += ( input.frame.data[1] + input.frame.data[3]
                                 + input.frame.data[5] + input.frame.data[7] ) * 256;
 
-            speed_report = speed_report / 4;
+                speed_report = speed_report / 4;
 
-            speed_report = speed_report * SPEED_RATIO;
+                speed_report = speed_report * SPEED_RATIO;
+            #endif
 
             break;
         }

--- a/example/roscco_apollo.h
+++ b/example/roscco_apollo.h
@@ -5,7 +5,6 @@
 #include <roscco/CanFrame.h>
 #include <modules/canbus/proto/chassis.pb.h>
 #include <modules/control/proto/control_cmd.pb.h>
-#include <modules/localization/proto/localization.pb.h>
 #include <roscco/pid_control.h>
 #include <string>
 #include <math.h>
@@ -62,13 +61,6 @@ private:
      * @param roscco can frame message to be consumed
      */
     void canFrameCallback( const roscco::CanFrame& input );
-    
-    /**
-     * @brief Callback function to log localization
-     *
-     * @param apollo localization message to be consumed
-     */
-    void localizationCallback( const apollo::localization::LocalizationEstimate& input );
 
     ros::NodeHandle nh;
 

--- a/example/roscco_apollo.h
+++ b/example/roscco_apollo.h
@@ -12,9 +12,14 @@
 #include <vehicles.h>
 
 #define THROTTLE_RATIO 0.393
-#define BRAKE_RATIO 0.115
 #define STEERING_RATIO 0.018
 #define SPEED_RATIO 0.02
+
+#if defined( KIA_SOUL_EV )
+    #define BRAKE_RATIO 0.115
+#elif defined( KIA_NIRO )
+    #define BRAKE_RATIO 0.033
+#endif
 
 class RosccoApollo
 {
@@ -55,7 +60,7 @@ private:
      *
      * @param roscco can frame message to be consumed
      */
-    void EVCanFrameCallback( const roscco::CanFrame& input );
+    void canFrameCallback( const roscco::CanFrame& input );
     
     /**
      * @brief Callback function to log localization

--- a/example/roscco_apollo.h
+++ b/example/roscco_apollo.h
@@ -16,10 +16,10 @@
 
 #if defined( KIA_SOUL_EV )
     #define BRAKE_RATIO 0.12
-    #define SPEED_RATIO 0.02
+    #define SPEED_RATIO 0.002
 #elif defined( KIA_NIRO )
     #define BRAKE_RATIO 0.033
-    #define SPEED_RATIO 0.66
+    #define SPEED_RATIO 0.3
 #endif
 
 class RosccoApollo

--- a/example/roscco_apollo.h
+++ b/example/roscco_apollo.h
@@ -13,12 +13,13 @@
 
 #define THROTTLE_RATIO 0.393
 #define STEERING_RATIO 0.018
-#define SPEED_RATIO 0.02
 
 #if defined( KIA_SOUL_EV )
-    #define BRAKE_RATIO 0.115
+    #define BRAKE_RATIO 0.12
+    #define SPEED_RATIO 0.02
 #elif defined( KIA_NIRO )
     #define BRAKE_RATIO 0.033
+    #define SPEED_RATIO 0.66
 #endif
 
 class RosccoApollo


### PR DESCRIPTION
This PR adds Apollo support to ROSCCO for use with the Kia Niro.
This PR also removes a callback feature for localization that is not necessary.