### PR TITLE
Update Jenkins Build Process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+WORKDIR /app
+
+# common packages
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential cmake git wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# add ROS packages to apt package manager
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list'
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# install ros
+RUN apt-get update && \
+    apt-get install -y ros-kinetic-ros-base
+
+# install arduino toolchain
+RUN wget -nv http://arduino.cc/download.php?f=/arduino-1.8.5-linux64.tar.xz -O arduino-1.8.5.tar.xz
+
+RUN tar -xf arduino-1.8.5.tar.xz && \
+    cd arduino-1.8.5 && \
+    mkdir -p /usr/share/arduino && \
+    cp -R * /usr/share/arduino

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,43 +1,67 @@
 #!groovy
-node('xenial') {
-  try {
-    stage('Checkout') {
-      sh 'mkdir -p catkin_ws/src/roscco'
-      dir('catkin_ws/src/roscco')
-      {
-        checkout([
-          $class: 'GitSCM',
-          branches: scm.branches,
-          doGenerateSubmoduleConfigurations: false,
-          extensions: scm.extensions + [[$class: 'CleanBeforeCheckout'],
-            [$class: 'SubmoduleOption',
-            disableSubmodules: false,
-            parentCredentials: true,
-            recursiveSubmodules: true,
-            reference: '',
-            trackingSubmodules: false]],
-          submoduleCfg: [],
-          userRemoteConfigs: scm.userRemoteConfigs
-        ])
-      }
+
+node() {
+    def builds = [:]
+    def platforms = [:]
+
+    sh 'mkdir -p catkin_ws/src/roscco'
+    dir('catkin_ws/src/roscco') {
+        checkout scm
+        sh "git submodule update --init --recursive"
+
+        def image = docker.build("catkin_make-build:${env.BUILD_ID}")
+
+
+        def output = image.inside {
+            sh returnStdout: true, script: "cmake -LA ./oscc/firmware | grep 'VEHICLE_VALUES' | cut -d'=' -f 2"
+        }
+
+        platforms = output.trim().tokenize(';')\
     }
-    stage('Build') {
-      parallel 'kia soul firmware': {
-        sh '. /opt/ros/kinetic/setup.sh && cd catkin_ws && catkin_make -DKIA_SOUL=ON'
-      }
-      echo 'Build Complete!'
+
+    for(int j=0; j<platforms.size(); j++) {
+        def platform_idx = j
+        def platform = platforms[platform_idx]
+        builds[platform] = {
+            node {
+                sh 'mkdir -p catkin_ws/src/roscco'
+                dir('catkin_ws/src/roscco') {
+                    checkout scm
+                    sh "git submodule update --init --recursive"
+                }
+
+                image = docker.build("catkin_make-build:${env.BUILD_ID}", "./catkin_ws/src/roscco")
+
+                stage("Build ${platform}"){
+                    image.inside {
+                        sh ". /opt/ros/kinetic/setup.sh && \
+                            cd catkin_ws && \
+                            catkin_make -DVEHICLE=${platform}"
+
+                        echo "${platform}: Build Complete!"
+                    }
+                }
+
+                def workspace = pwd()
+
+                stage("Test ${platform}"){
+                    image.inside{
+                        sh ". /opt/ros/kinetic/setup.sh && \
+                            cd catkin_ws && \
+                            catkin_make -DVEHICLE=${platform} && \
+                            ROS_HOME=${workspace} ROS_LOG_DIR=${workspace} catkin_make run_tests -DVEHICLE=${platform} && \
+                            catkin_test_results"
+                    }
+                }
+            }
+        }
     }
-    stage('Test') {
-      parallel 'kia soul tests': {
-        sh '. /opt/ros/kinetic/setup.sh && cd catkin_ws && catkin_make run_tests -DKIA_SOUL=ON && catkin_test_results'
-        echo 'ROS Tests Complete!'
-      }
+
+    try {
+        parallel builds
     }
-    stage('Release') {
-      echo 'Release Package Created!'
+    finally {
+        deleteDir()
     }
-  }
-  finally {
-    deleteDir()
-  }
+
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ node() {
                             cd catkin_ws && \
                             catkin_make -DVEHICLE=${platform} && \
                             ROS_HOME=${workspace} ROS_LOG_DIR=${workspace} catkin_make run_tests -DVEHICLE=${platform} && \
-                            catkin_test_results"
+                            catkin_test_results --verbose"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,6 @@ node() {
                     image.inside{
                         sh ". /opt/ros/kinetic/setup.sh && \
                             cd catkin_ws && \
-                            catkin_make -DVEHICLE=${platform} && \
                             ROS_HOME=${workspace} ROS_LOG_DIR=${workspace} catkin_make run_tests -DVEHICLE=${platform} && \
                             catkin_test_results --verbose"
                     }

--- a/test/test_oscc_to_ros.cpp
+++ b/test/test_oscc_to_ros.cpp
@@ -7,7 +7,7 @@
 #include <roscco/oscc_to_ros.h>
 
 // Time to allow ROS to process callbacks and publish a message
-const double SLEEP_TIME = 0.02;
+const double SLEEP_TIME = 0.05;
 
 template <class T>
 class MessageHelper


### PR DESCRIPTION
This pull request updates the Jenkins build process for the new build system by adding a Dockerfile of the ROSCCO dependencies and updating the Jenkins file to use the docker image.

The sleep time for some of the tests has been increased by 2ms because of the delay in message passing found when running the docker images on the build instances.